### PR TITLE
Hide quit option for WebGL builds

### DIFF
--- a/Assets/Scripts/ExitController.cs
+++ b/Assets/Scripts/ExitController.cs
@@ -31,9 +31,15 @@ public class ExitController : MonoBehaviour, IPulsable
             return;
         }
 
+        // No more levels - handle end of game
+#if UNITY_WEBGL
+        // For WebGL, return to title screen instead of quitting
+        SceneManager.LoadScene("TitleScreen");
+#else
         Application.Quit();
-#if UNITY_EDITOR
+        #if UNITY_EDITOR
         UnityEditor.EditorApplication.isPlaying = false;
+        #endif
 #endif
     }
 

--- a/Assets/Scripts/TitleMenuController.cs
+++ b/Assets/Scripts/TitleMenuController.cs
@@ -37,6 +37,7 @@ public class TitleMenuController : MonoBehaviour
         if (!canInput) return;
 
         // Navigation
+        #if !UNITY_WEBGL
         if (Input.GetKeyDown(KeyCode.UpArrow) || Input.GetKeyDown(KeyCode.W))
         {
             currentSelection = 0;
@@ -47,6 +48,7 @@ public class TitleMenuController : MonoBehaviour
             currentSelection = 1;
             StartCoroutine(InputCooldown());
         }
+        #endif
 
         // Selection
         if (Input.GetKeyDown(KeyCode.Return) || Input.GetKeyDown(KeyCode.Space))
@@ -66,13 +68,15 @@ public class TitleMenuController : MonoBehaviour
 
         // Menu options
         string startPrefix = currentSelection == 0 ? "> " : "  ";
-        string quitPrefix = currentSelection == 1 ? "> " : "  ";
-
         GUIStyle startStyle = currentSelection == 0 ? selectedStyle : menuStyle;
-        GUIStyle quitStyle = currentSelection == 1 ? selectedStyle : menuStyle;
 
         GUI.Label(new Rect(0, screenHeight * 0.5f, screenWidth, 50), startPrefix + "Start Game", startStyle);
+
+        #if !UNITY_WEBGL
+        string quitPrefix = currentSelection == 1 ? "> " : "  ";
+        GUIStyle quitStyle = currentSelection == 1 ? selectedStyle : menuStyle;
         GUI.Label(new Rect(0, screenHeight * 0.6f, screenWidth, 50), quitPrefix + "Quit", quitStyle);
+        #endif
 
         // Instructions
         GUIStyle instructionStyle = new GUIStyle(menuStyle);
@@ -88,6 +92,7 @@ public class TitleMenuController : MonoBehaviour
             // Start Game - Load Level1
             SceneManager.LoadScene("Level1");
         }
+        #if !UNITY_WEBGL
         else if (currentSelection == 1)
         {
             // Quit Game
@@ -97,6 +102,7 @@ public class TitleMenuController : MonoBehaviour
                 Application.Quit();
             #endif
         }
+        #endif
     }
 
     IEnumerator InputCooldown()


### PR DESCRIPTION
## Summary
- Hides the "Quit" option from the title menu in WebGL builds using conditional compilation
- Updates ExitController to return to title screen instead of quitting when all levels are complete
- Improves user experience by removing non-functional quit button that previously made the game unresponsive

## Changes Made
- **TitleMenuController.cs**: Wrapped quit menu option and navigation logic with `#if !UNITY_WEBGL` directives
- **ExitController.cs**: Added WebGL-specific handling to return to title screen when game is complete

## Test plan
- [x] Build for WebGL and verify quit option is hidden from title menu
- [x] Verify only "Start Game" appears in WebGL title menu
- [x] Complete all levels and confirm return to title screen (not quit)
- [x] Test non-WebGL builds still show quit option and function correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)